### PR TITLE
Add missing resource in podspec

### DIFF
--- a/YoutubeKit.podspec
+++ b/YoutubeKit.podspec
@@ -16,5 +16,6 @@ YoutubeKit is a video player that fully supports Youtube IFrame API and YoutubeD
   s.ios.deployment_target = '9.0'
 
   s.source_files = 'YoutubeKit/**/*'
- 
+  s.resources    = 'YoutubeKit/player.html'
+
  end


### PR DESCRIPTION
Example app crashed due to `player.html` missing in the framework.
I only changed podspec in this PR, so please `pod install` afterward.