### PR TITLE
fix decode problem of videos with no `tags` field  (issue #21)

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -109,19 +109,19 @@
 		07F13D22BA7E5755F9E576A825ADF22B /* CaptionList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptionList.swift; sourceTree = "<group>"; };
 		08C84439B66D083ADEF24368FFDFD1AA /* SubscriptionsListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionsListRequest.swift; sourceTree = "<group>"; };
 		11A11355A96319399025368D6C0FB775 /* SearchVideoDimension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchVideoDimension.swift; sourceTree = "<group>"; };
-		134FFB3625EEAC42003339E6A9DD5D7A /* player.html */ = {isa = PBXFileReference; includeInIndex = 1; name = player.html; path = YoutubeKit/player.html; sourceTree = "<group>"; };
+		134FFB3625EEAC42003339E6A9DD5D7A /* player.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; name = player.html; path = YoutubeKit/player.html; sourceTree = "<group>"; };
 		13E3219E7624BA41C9E98861BC2BD848 /* VideoListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoListRequest.swift; sourceTree = "<group>"; };
 		142B68CA7DCA985460B94C6EB1695F15 /* Snippet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		1538CBED29FCF11DBDD9F221BE8A5760 /* PlaylistItemsList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlaylistItemsList.swift; sourceTree = "<group>"; };
 		154E56365A6E383C574E1F66A6FD687C /* ApiSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApiSession.swift; sourceTree = "<group>"; };
 		1A1F4552BF679B9CC76BAA390F369521 /* YTSwiftyConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YTSwiftyConstants.swift; sourceTree = "<group>"; };
-		1BA5A092840F4E69082BA7E269B156E1 /* YoutubeKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = YoutubeKit.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		1BA5A092840F4E69082BA7E269B156E1 /* YoutubeKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = YoutubeKit.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		1C3A0B17441471C5B4E1EE678F746400 /* CommentThreadsListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommentThreadsListRequest.swift; sourceTree = "<group>"; };
 		2135366C52821DE9560F9A5B956F7BD5 /* RequestError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestError.swift; sourceTree = "<group>"; };
 		21B3EA52A9F27ECA53608B2EC47078F2 /* Pods-YoutubeKit_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-YoutubeKit_Tests-resources.sh"; sourceTree = "<group>"; };
 		225D08384E3B1E1B28816CC6FCAF9856 /* CommentTextFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommentTextFormat.swift; sourceTree = "<group>"; };
 		261ECAED7515B7BEE70249CB444B6784 /* Part.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Part.swift; sourceTree = "<group>"; };
-		2A3E7ED96C6511B468FA8E3F67EDFFC3 /* Pods_YoutubeKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_YoutubeKit_Example.framework; path = "Pods-YoutubeKit_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A3E7ED96C6511B468FA8E3F67EDFFC3 /* Pods_YoutubeKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YoutubeKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B4E60FAFDFBB16A5F079DC5AF89055F /* SearchSafeMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchSafeMode.swift; sourceTree = "<group>"; };
 		30E72139869050455C1CB6A9104205C4 /* Pods-YoutubeKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-YoutubeKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		3327913441D29FC01E21A4D93BFA159C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -139,11 +139,11 @@
 		5911B7ED5D5AEE9ECEBF8B69E028802B /* Pods-YoutubeKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-YoutubeKit_Example-frameworks.sh"; sourceTree = "<group>"; };
 		5C2CEDF788FBF41F9E1D1E89220B2288 /* Pods-YoutubeKit_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-YoutubeKit_Example-umbrella.h"; sourceTree = "<group>"; };
 		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		68FF1EC55359F116E26673BE8DDC24F9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		68FF1EC55359F116E26673BE8DDC24F9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		6BBAB899BCC66D54B2CD9852D0F3B368 /* RequestableExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RequestableExtensions.swift; sourceTree = "<group>"; };
 		6E951D3D1BF1D504F4849AAA7BA5580C /* Pods-YoutubeKit_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-YoutubeKit_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		70A9B65D89A34627EAE4BAA4D6D38C2E /* PageInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PageInfo.swift; sourceTree = "<group>"; };
-		713358CC69142E9C7FA41D987CF589ED /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		713358CC69142E9C7FA41D987CF589ED /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; tabWidth = 4; };
 		717F25F185D41465654C763EA29AB841 /* Pods-YoutubeKit_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-YoutubeKit_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		73700093EC935A1805A0CAA9A96B0D47 /* Requestable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		756CF377688DFE9317EBBB02313E8A6E /* ChannelSectionsListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChannelSectionsListRequest.swift; sourceTree = "<group>"; };
@@ -161,7 +161,7 @@
 		8F0CE030B6D9A41BD133DE8FACF7F4B3 /* MyRating.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MyRating.swift; sourceTree = "<group>"; };
 		9039FD432FAF4E3E88115BEDDE186542 /* ChannelList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChannelList.swift; sourceTree = "<group>"; };
 		939835BDA5FB2E04DF7FFB975A75F589 /* YoutubeKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = YoutubeKit.modulemap; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9523DE1DF3097E372CD4A59AE5488394 /* Pods-YoutubeKit_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-YoutubeKit_Tests-dummy.m"; sourceTree = "<group>"; };
 		9A33AF1FE2225DDD8A698C1AB2ACFE42 /* ContentDetails.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentDetails.swift; sourceTree = "<group>"; };
 		9A53450CEF29F276998F2404723E5396 /* Pods-YoutubeKit_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-YoutubeKit_Example-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -173,7 +173,7 @@
 		A70702D7B86DACAC8324BB3F1D731E49 /* SearchVideoEmbeddable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchVideoEmbeddable.swift; sourceTree = "<group>"; };
 		A7C6AED2ABAC979D318C6775570887FC /* Localized.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
 		A8CAEE09EA00AB37EA4C75C26A1B03E6 /* VideoCategoriesList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoCategoriesList.swift; sourceTree = "<group>"; };
-		ACD3FA5A552AF9C6D5FEEC3EA092C255 /* Pods_YoutubeKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_YoutubeKit_Tests.framework; path = "Pods-YoutubeKit_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACD3FA5A552AF9C6D5FEEC3EA092C255 /* Pods_YoutubeKit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YoutubeKit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B54BC34679D2F6A106C543C2EC1941B8 /* CommentList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommentList.swift; sourceTree = "<group>"; };
 		B82C6511AD485A4AFA113209309381D3 /* CommentListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommentListRequest.swift; sourceTree = "<group>"; };
 		BDB782B69244E68B4A7313D71E81F8B4 /* Pods-YoutubeKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-YoutubeKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -187,12 +187,12 @@
 		C631292370DC6E1C65A5A435E8480890 /* Pods-YoutubeKit_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-YoutubeKit_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		C6A2AE083D991F21C40D4093CC3BA720 /* I18nRegionsListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = I18nRegionsListRequest.swift; sourceTree = "<group>"; };
 		C76F78ADC57D167A77EF582C131874FC /* SearchVideoDuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchVideoDuration.swift; sourceTree = "<group>"; };
-		CA0E7E728E9164CDCD91BD9AB17C5BB3 /* YoutubeKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = YoutubeKit.framework; path = YoutubeKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA0E7E728E9164CDCD91BD9AB17C5BB3 /* YoutubeKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YoutubeKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDA245DFB8CC3B8EA4159374CFAA6D04 /* PlaylistsList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlaylistsList.swift; sourceTree = "<group>"; };
 		D1F098CCC880E2E58D21E01814CF5AFE /* YTSwiftyPlayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YTSwiftyPlayer.swift; sourceTree = "<group>"; };
 		D2347BFD9E8DA48E8D5BCED9FD4398B2 /* ResourceID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResourceID.swift; sourceTree = "<group>"; };
 		D2B08FFA8064B788769552BB6B7FF61B /* CaptionListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptionListRequest.swift; sourceTree = "<group>"; };
-		D32B9033A71F1F2EA2FAE03DB4C37B81 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		D32B9033A71F1F2EA2FAE03DB4C37B81 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D561B370484C2F987BD7F2CFD9CDA6BB /* QueryParameterable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QueryParameterable.swift; sourceTree = "<group>"; };
 		D607FDA331CA78E6CCDD49EFE5930D31 /* HTTPMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		DB20C6E7FA3A2234FFEB2570D36DBB0F /* VideoAbuseReportReasonsListRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAbuseReportReasonsListRequest.swift; sourceTree = "<group>"; };
@@ -296,7 +296,6 @@
 				A8CAEE09EA00AB37EA4C75C26A1B03E6 /* VideoCategoriesList.swift */,
 				E8B6C84D8F0FBBAE2374D4241CDB4846 /* VideoList.swift */,
 			);
-			name = Models;
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -439,7 +438,6 @@
 				35CC7A2D48C6EC38E2E059B26A2BBAC7 /* VideoCategoryListRequest.swift */,
 				13E3219E7624BA41C9E98861BC2BD848 /* VideoListRequest.swift */,
 			);
-			name = Requests;
 			path = Requests;
 			sourceTree = "<group>";
 		};
@@ -492,7 +490,6 @@
 				4E042875718209F8313FC37685B94DB4 /* SearchVideoType.swift */,
 				C1D8A503AEBF8A2EBC00EA049EDFCED9 /* VideoCategory.swift */,
 			);
-			name = Constants;
 			path = Constants;
 			sourceTree = "<group>";
 		};

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/YoutubeKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/YoutubeKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/YoutubeKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/YoutubeKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/YoutubeKit/API/ApiSession.swift
+++ b/YoutubeKit/API/ApiSession.swift
@@ -21,19 +21,28 @@ public class ApiSession {
             
             // If the dataTask error is occured.
             if let error = error {
-                closure(.failed(ResponseError.unexpectedResponse(error)))
+                DispatchQueue.main.async {
+                    closure(.failed(ResponseError.unexpectedResponse(error)))
+                }
+                
                 return
             }
             
             // Decodable must have data length at least.
             guard let data = data else {
-                closure(.failed(ResponseError.unexpectedResponse("The response is empty.")))
+                DispatchQueue.main.async {
+                    closure(.failed(ResponseError.unexpectedResponse("The response is empty.")))
+                }
+                
                 return
             }
             
             // rawResponse must be HTTPURLResponse
             guard let httpResponse = rawResponse as? HTTPURLResponse else {
-                closure(.failed(ResponseError.unexpectedResponse("The response is not a HTTPURLResponse")))
+                DispatchQueue.main.async {
+                    closure(.failed(ResponseError.unexpectedResponse("The response is not a HTTPURLResponse")))
+                }
+                
                 return
             }
             
@@ -43,29 +52,52 @@ public class ApiSession {
                     let errJson = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
                     print(errJson) //print error json object if data is serializable
                 } catch let serializationError {
-                    closure(.failed(ResponseError.unexpectedResponse(serializationError)))
+                    DispatchQueue.main.async {
+                      closure(.failed(ResponseError.unexpectedResponse(serializationError)))
+                    }
                 }
-            
-                closure(.failed(ResponseError.unacceptableStatusCode(httpResponse.statusCode)))
+                
+                DispatchQueue.main.async {
+                  closure(.failed(ResponseError.unacceptableStatusCode(httpResponse.statusCode)))
+                }
+                
                 return
             }
-            
-            
+          
             // Decoding the response from `data` and handle DecodingError if occured.
             do {
                 let decoder = JSONDecoder()
                 let result = try decoder.decode(T.Response.self, from: data)
-                closure(.success(result))
+                
+                DispatchQueue.main.async {
+                  closure(.success(result))
+                }
+                
             } catch DecodingError.keyNotFound(let codingKey, let context){
-                closure(.failed(DecodingError.keyNotFound(codingKey, context)))
+                DispatchQueue.main.async {
+                  closure(.failed(DecodingError.keyNotFound(codingKey, context)))
+                }
+                
             } catch DecodingError.typeMismatch(let type, let context){
-                closure(.failed(DecodingError.typeMismatch(type, context)))
+                DispatchQueue.main.async {
+                  closure(.failed(DecodingError.typeMismatch(type, context)))
+                }
+                
             } catch DecodingError.valueNotFound(let type, let context) {
-                closure(.failed(DecodingError.valueNotFound(type, context)))
+                DispatchQueue.main.async {
+                  closure(.failed(DecodingError.valueNotFound(type, context)))
+                }
+                
             } catch DecodingError.dataCorrupted(let context) {
-                closure(.failed(DecodingError.dataCorrupted(context)))
+                DispatchQueue.main.async {
+                  closure(.failed(DecodingError.dataCorrupted(context)))
+                }
+                
             } catch {
-                closure(.failed(ResponseError.unexpectedResponse(data)))
+                DispatchQueue.main.async {
+                  closure(.failed(ResponseError.unexpectedResponse(data)))
+                }
+                
             }
         }
         

--- a/YoutubeKit/API/Models/PlaylistsList.swift
+++ b/YoutubeKit/API/Models/PlaylistsList.swift
@@ -20,8 +20,8 @@ public struct Playlist: Codable {
     public let etag: String
     public let id: String
     public let kind: String
-    public let snippet: Snippet.PlaylistsList
-    public let status: PlaylistsStatus
+    public let snippet: Snippet.PlaylistsList?
+    public let status: PlaylistsStatus?
 }
 
 public struct PlaylistsStatus: Codable {

--- a/YoutubeKit/API/Models/Snippet.swift
+++ b/YoutubeKit/API/Models/Snippet.swift
@@ -15,7 +15,7 @@ extension Snippet {
         public let categoryID: String
         public let channelTitle: String
         public let localized: Localized
-        public let tags: [String]
+        public let tags: [String]?
         public let liveBroadcastContent: String
         public let publishedAt: String
         public let thumbnails: Thumbnails.VideoList

--- a/YoutubeKit/API/Models/Thumbnail.swift
+++ b/YoutubeKit/API/Models/Thumbnail.swift
@@ -69,13 +69,15 @@ extension Thumbnails {
         public let high: Default
         public let medium: Default
         public let `default`: Default
-        public let standard: Default
+        public let standard: Default?
+        public let maxres: Default?
         
         public enum CodingKeys: String, CodingKey {
             case high = "high"
             case medium = "medium"
             case `default` = "default"
             case standard = "standard"
+            case maxres = "maxres"
         }
     }
 }

--- a/YoutubeKit/Common/Result.swift
+++ b/YoutubeKit/Common/Result.swift
@@ -10,4 +10,21 @@ import Foundation
 public enum Result<T, E> {
     case success(T)
     case failed(E)
+    public var value: T? {
+        switch self {
+        case .success(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+    
+    public var error: E? {
+        switch self {
+        case .failed(let error):
+            return error
+        default:
+            return nil
+        }
+    }
 }

--- a/YoutubeKit/Player/YTSwiftyPlayer.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayer.swift
@@ -219,7 +219,7 @@ open class YTSwiftyPlayer: WKWebView {
     }
 
     public func loadPlayer() {
-        let currentBundle = Bundle(for: type(of: self))
+        let currentBundle = Bundle(for: YTSwiftyPlayer.self)
         let path = currentBundle.path(forResource: "player", ofType: "html")!
         let htmlString = try? String(contentsOfFile: path, encoding: String.Encoding.utf8)
         let events: [String: AnyObject] = {

--- a/YoutubeKit/Player/YTSwiftyPlayerDelegate.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayerDelegate.swift
@@ -78,7 +78,7 @@ public protocol YTSwiftyPlayerDelegate: class {
 }
 
 // Default implementation of delegate methods, These delegate functions are option.
-extension YTSwiftyPlayerDelegate {
+public extension YTSwiftyPlayerDelegate {
 
     /**
       * Invoked when player state has changed.


### PR DESCRIPTION
1. make const `tags` at Snippet.swift line 18 as optional
2. add status code guard clause in ApiSession.swift
3. make Default implementation of YTSwiftyPlayerDelegate methods public so that they are optional

Closes #21