### PR TITLE
#Load html with correct baseUrl to be able to play every youtube videos

### DIFF
--- a/YoutubeKit/Player/YTSwiftyPlayer.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayer.swift
@@ -243,9 +243,10 @@ open class YTSwiftyPlayer: WKWebView {
         
         guard let json = try? JSONSerialization.data(withJSONObject: parameters, options: []),
             let jsonString = String(data: json, encoding: String.Encoding.utf8),
-            let html = htmlString?.replacingOccurrences(of: "%@", with: jsonString) else { return }
+            let html = htmlString?.replacingOccurrences(of: "%@", with: jsonString),
+            let baseUrl = URL(string: "https://www.youtube.com") else { return }
         
-        loadHTMLString(html, baseURL: nil)
+        loadHTMLString(html, baseURL: baseUrl)
     }
     
     // MARK: - Private Methods


### PR DESCRIPTION
When trying to play some videos (for example id : iPGgnzc34tY), the video cannot be played.

I changed baseUrl when loading WebView to enable cross domain loading.