### PR TITLE
Implemented Channel thumbnails

### DIFF
--- a/YoutubeKit/API/Models/Snippet.swift
+++ b/YoutubeKit/API/Models/Snippet.swift
@@ -96,7 +96,7 @@ extension Snippet {
         public let description: String
         public let localized: Localized
         public let publishedAt: String
-        public let thumbnails: Thumbnails.Default
+        public let thumbnails: Thumbnails.ChannelList
         public let title: String
         
         public enum CodingKeys: String, CodingKey {

--- a/YoutubeKit/API/Models/Thumbnail.swift
+++ b/YoutubeKit/API/Models/Thumbnail.swift
@@ -47,6 +47,20 @@ extension Thumbnails {
 }
 
 extension Thumbnails {
+    public struct ChannelList: Codable {
+        public let high: Default
+        public let `default`: Default
+        public let medium: Default
+        
+        public enum CodingKeys: String, CodingKey {
+            case high
+            case `default` = "default"
+            case medium
+        }
+    }
+}
+
+extension Thumbnails {
     public struct ActivityList: Codable {
         public let high: Default
         public let medium: Default


### PR DESCRIPTION
This is a quick fix for the missing structs required to decode the ChannelList thumbnails from the incoming JSON. It basically behaves just like the VideoList thumbnails (since the data from the API is basically equal).