### PR TITLE
Added CodingKeys to BrandingSettings struct to fix the error.

### DIFF
--- a/YoutubeKit/API/Models/ChannelList.swift
+++ b/YoutubeKit/API/Models/ChannelList.swift
@@ -47,6 +47,11 @@ public struct BrandingSettings: Codable {
     public let channelMetadata: ChannelMetadata
     public let hints: [Hint]
     public let image: Image
+    
+    public enum CodingKeys: String, CodingKey {
+        case channelMetadata = "channel"
+        case hints,image
+    }
 }
 
 public struct Image: Codable {


### PR DESCRIPTION
When your try to get .brandingSettings from ChannelListRequest like that 
`let requestChannel = ChannelListRequest(part: [.brandingSettings], filter: .id("yourID"))`
you'll get an error that says there is some problem with channelMetadata CodingKey. The API returns just "channel" instead of "channelMetadata" and if you replace CodingKeys in BrandingSettings struct you will get the response. 