### PR TITLE
fix value for "cued" state and add "default" quality

### DIFF
--- a/YoutubeKit/Player/YTSwiftyConstants.swift
+++ b/YoutubeKit/Player/YTSwiftyConstants.swift
@@ -17,7 +17,7 @@ public enum YTSwiftyPlayerState: Int {
     case playing    = 1
     case paused     = 2
     case buffering  = 3
-    case cued       = 4
+    case cued       = 5
 }
 
 /**
@@ -49,6 +49,7 @@ public enum YTSwiftyVideoQuality: String {
     case hd720      = "hd720"
     case hd1080     = "hd1080"
     case highres    = "highres"
+    case auto       = "default"
     case unknown
 }
 


### PR DESCRIPTION
According to the [API reference](https://developers.google.com/youtube/iframe_api_reference#Playback_status) the integer value for the "cued" state is 5. I have verified that the player does see this value some time after calling a cue method. This also adds the "default" quality under the name "auto".