### PR TITLE
Fixes rule to process html file warning

### DIFF
--- a/YoutubeKit.podspec
+++ b/YoutubeKit.podspec
@@ -15,7 +15,7 @@ YoutubeKit is a video player that fully supports Youtube IFrame API and YoutubeD
 
   s.ios.deployment_target = '9.0'
 
-  s.source_files = 'YoutubeKit/**/*'
+  s.source_files = 'YoutubeKit/**/*.swift'
   s.resources    = 'YoutubeKit/player.html'
 
  end


### PR DESCRIPTION
### Current Behaviour

![Screenshot 2019-09-05 at 09 33 22](https://user-images.githubusercontent.com/1882080/64325577-577d2300-cfc0-11e9-8a09-6b73162f75b2.png)

### Expected Behaviour

No warning should be triggered when importing `YoutubeKit`.

### Overview

The file `player.html` is currently included in the source files to compile because no extension is specified in the podspec, and `player.html` is in the same directory as the other source files.