### PR TITLE
Fix failing decode of Statistics

### DIFF
--- a/YoutubeKit/API/Models/Statistics.swift
+++ b/YoutubeKit/API/Models/Statistics.swift
@@ -13,7 +13,7 @@ public enum Statistics {}
 extension Statistics {
     public struct VideoList: Codable {
         public let dislikeCount: String?
-        public let likeCount: String
+        public let likeCount: String?
         public let commentCount: String?
         public let favoriteCount: String
         public let viewCount: String


### PR DESCRIPTION
Because Youtube authorize a creator to disable the like count, if this parameter is disabled for a video, then the API doesn't return anymore the likeCount, which makes the decode of the struct fails, making the whole request response decode failing if statistics part was requested.