### PR TITLE
Add standard and maxres in Thumbnails.VideoList

### DIFF
--- a/YoutubeKit/API/Models/Thumbnail.swift
+++ b/YoutubeKit/API/Models/Thumbnail.swift
@@ -34,14 +34,18 @@ extension Thumbnails {
 
 extension Thumbnails {
     public struct VideoList: Codable {
-        public let high: Default
         public let `default`: Default
         public let medium: Default
+        public let high: Default
+        public let standard: Default?
+        public let maxres: Default?
         
         public enum CodingKeys: String, CodingKey {
-            case high
             case `default` = "default"
             case medium
+            case high
+            case standard
+            case maxres
         }
     }
 }


### PR DESCRIPTION
These thumbnails resolutions were missing and even if they are optional (it seems they are available only for some videos (not all and probably not for old video or video with low quality)) they can be useful, indeed the `maxres` is the best quality and in ratio 16:9 so without black borders on top and bottom.

Source: https://developers.google.com/youtube/v3/docs/videos#snippet.thumbnails