### PR TITLE
fix: Resolve optional Thumbnails when requesting PlaylistItems

### DIFF
--- a/YoutubeKit/API/Models/PlaylistItemsList.swift
+++ b/YoutubeKit/API/Models/PlaylistItemsList.swift
@@ -17,12 +17,12 @@ public struct PlaylistItemsList: Codable {
 }
 
 public struct PlaylistItem: Codable {
-    public let contentDetails: ContentDetails.PlaylistItemsList
+    public let kind: String
     public let etag: String
     public let id: String
-    public let kind: String
-    public let snippet: Snippet.PlaylistItemsList
-    public let status: PlaylistItemsStatus
+    public let snippet: Snippet.PlaylistItemsList?
+    public let contentDetails: ContentDetails.PlaylistItemsList?
+    public let status: PlaylistItemsStatus?
 }
 
 public struct PlaylistItemsStatus: Codable {

--- a/YoutubeKit/API/Models/Snippet.swift
+++ b/YoutubeKit/API/Models/Snippet.swift
@@ -241,23 +241,29 @@ extension Snippet {
     public struct PlaylistItemsList: Codable {
         public let channelID: String
         public let channelTitle: String
+        public let videoOwnerChannelTitle: String?
+        public let videoOwnerChannelId: String?
         public let description: String
-        public let playlistID: String
+        public let thumbnails: Thumbnails.PlaylistItemsList?
+        public let channelId: String
+        public let playlistId: String
         public let position: Int
         public let publishedAt: String
         public let resourceID: ResourceID.PlaylistItemsList
-        public let thumbnails: Thumbnails.PlaylistItemsList?
         public let title: String
         
         public enum CodingKeys: String, CodingKey {
             case channelID = "channelId"
             case channelTitle
+            case videoOwnerChannelTitle
+            case videoOwnerChannelId
             case description
-            case playlistID = "playlistId"
+            case thumbnails
+            case channelId
+            case playlistId
             case position
             case publishedAt
             case resourceID = "resourceId"
-            case thumbnails
             case title
         }
     }

--- a/YoutubeKit/API/Models/Thumbnail.swift
+++ b/YoutubeKit/API/Models/Thumbnail.swift
@@ -102,14 +102,18 @@ extension Thumbnails {
 
 extension Thumbnails {
     public struct PlaylistItemsList: Codable {
-        public let high: Default
-        public let medium: Default
-        public let `default`: Default
+        public let `default`: Default?
+        public let high: Default?
+        public let medium: Default?
+        public let standard: Default?
+        public let maxres: Default?
         
         public enum CodingKeys: String, CodingKey {
-            case high = "high"
-            case medium = "medium"
             case `default` = "default"
+            case high
+            case medium
+            case standard
+            case maxres
         }
     }
 }


### PR DESCRIPTION
This pull request includes several important changes to the `YoutubeKit` API models to enhance flexibility and robustness. The changes primarily focus on making certain fields optional and adding new fields to better represent the data structure.

### Enhancements to `PlaylistItem` and related models:

* [`YoutubeKit/API/Models/PlaylistItemsList.swift`](diffhunk://#diff-879e0440955c367248a2a4857ed6cf9ab9d091a7b78144bc57803c58dfe965deL20-R25): Modified the `PlaylistItem` struct to make `snippet`, `contentDetails`, and `status` optional, and reordered the fields.
* [`YoutubeKit/API/Models/Snippet.swift`](diffhunk://#diff-f2c0075427402af27497222422f185545ce075474cae3d967fa370c3efaa0e0dR244-L260): Added new optional fields `videoOwnerChannelTitle` and `videoOwnerChannelId` to the `Snippet.PlaylistItemsList` struct. Also, made `thumbnails` optional and renamed `playlistID` to `playlistId`.
* [`YoutubeKit/API/Models/Thumbnail.swift`](diffhunk://#diff-dc653979bf9fbc0e21f34f52ef50a0ecc12767073084966ecd59104d1be3a0e1L105-R116): Updated the `Thumbnails.PlaylistItemsList` struct to make `default`, `high`, and `medium` optional, and added new optional fields `standard` and `maxres`.