### PR TITLE
Add ability to get contentDetails for PlaylistsList

### DIFF
--- a/YoutubeKit/API/Constants/Part.swift
+++ b/YoutubeKit/API/Constants/Part.swift
@@ -114,6 +114,7 @@ extension Part {
     public enum PlaylistsList: String {
         case id
         case snippet
+        case contentDetails
         case status
     }
 }

--- a/YoutubeKit/API/Models/ContentDetails.swift
+++ b/YoutubeKit/API/Models/ContentDetails.swift
@@ -46,6 +46,12 @@ extension ContentDetails {
 }
 
 extension ContentDetails {
+    public struct PlaylistsList: Codable {
+        public let itemCount: Int
+    }
+}
+
+extension ContentDetails {
     public struct PlaylistItemsList: Codable {
         public let videoID: String
         public let videoPublishedAt: String

--- a/YoutubeKit/API/Models/PlaylistsList.swift
+++ b/YoutubeKit/API/Models/PlaylistsList.swift
@@ -21,6 +21,7 @@ public struct Playlist: Codable {
     public let id: String
     public let kind: String
     public let snippet: Snippet.PlaylistsList?
+    public let contentDetails: ContentDetails.PlaylistsList?
     public let status: PlaylistsStatus?
 }
 


### PR DESCRIPTION
The `contentDetails` part was missing and impossible to request. 
Nevertheless this part is interesting because it contains the `itemCount` property which is the number of videos in the playlist.