### PR TITLE
Fix YouTube video playback errors by updating base URL to youtube-nocookie.com

### DIFF
--- a/YoutubeKit/Player/YTSwiftyPlayer.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayer.swift
@@ -71,7 +71,7 @@ open class YTSwiftyPlayer: WKWebView {
 
     public enum Const {
         /// url: https://www.youtube.com
-        public static let basePlayerURLString = "https://www.youtube.com"
+        public static let basePlayerURLString = "https://www.youtube-nocookie.com"
     }
 
     public init(frame: CGRect = .zero, playerVars: [String: AnyObject]) {


### PR DESCRIPTION
## 🐛 Problem
YouTube recently changed their API policies, causing video playback to fail with Error 152 and Error 150 when using `www.youtube.com` as the base URL for embedded players.

## ✅ Solution
Updated the base URL from `https://www.youtube.com` to `https://www.youtube-nocookie.com` in `YTSwiftyPlayer.swift`.

## 🔧 Changes
- Changed `basePlayerURLString` constant in `YTSwiftyPlayer.swift`
- Uses YouTube's official privacy-focused domain for embedded content

## �� Why this works
- `youtube-nocookie.com` is Google's official domain for embedded YouTube content
- Provides same functionality as youtube.com but with enhanced privacy
- Resolves the recent API changes that broke video playback
- Follows the same solution implemented in other YouTube libraries (e.g., youtube_player_flutter)

## 🧪 Testing
- Video playback now works correctly
- No more Error 152 or Error 150
- Maintains all existing functionality

## 🔗 References
- Related issue: #109 
- Similar fix: https://github.com/sarbagyastha/youtube_player_flutter/pull/1086